### PR TITLE
Fix post-win action execution

### DIFF
--- a/lib/game_window.rb
+++ b/lib/game_window.rb
@@ -51,6 +51,7 @@ class GameWindow < Gosu::Window
 
   def handle_input
     close if Gosu.button_down?(Gosu::KB_ESCAPE)
+    require 'pry'; binding.pry if Gosu.button_down?(Gosu::KB_P)
 
     if game_state.on_title_screen
       if Gosu.button_down?(Gosu::MS_LEFT)

--- a/lib/game_window.rb
+++ b/lib/game_window.rb
@@ -75,6 +75,7 @@ class GameWindow < Gosu::Window
     if Gosu.button_down?(Gosu::MS_LEFT)
       card = ui.action_for_coordinates(self.mouse_x, self.mouse_y)
       return unless card # Nothing clicked.
+      return if level.complete?
 
       game_state.input_locked = true
       character.perform(card)


### PR DESCRIPTION
Also, a bonus! I added a little debug entrypoint for some introspection abilities. Smash `p` at any time to pause the game loop and pop open a `pry` session in the terminal that you launched the game from. [Pry is a repl](https://github.com/pry/pry) that you can summon at runtime by inserting `binding.pry` anywhere in your code; it functions similar to pause-able breakpoint debugging you find in fancy IDEs.

After pressing `p`, you'll see:
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/1123917/235331714-9882f59b-03a9-421f-ac61-7362b6656a09.png">
^ this is the output from typing the `ls` pry command. You can `cd` into and out of objects that you can see in the local context, it's pretty awesome. I used it to try to track down why `window.game_state.input_locked` was false when I was expecting it to be true; :goat: tool mega-goaty :goat: